### PR TITLE
Add groups to user fix

### DIFF
--- a/DayCareApp/backend/app_auth/serializers.py
+++ b/DayCareApp/backend/app_auth/serializers.py
@@ -34,7 +34,9 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
             #Sets a password for the user instance. Django automatically hashes the password before storing
             user.set_password(validated_data['password'])
             #Adds groups to the user
-            user.groups.set(validated_data['groups'])
+            user.save()
+            for group_id in validated_data['groups']:
+                user.groups.add(group_id)
             user.save()
 
             return user

--- a/DayCareApp/backend/app_auth/views.py
+++ b/DayCareApp/backend/app_auth/views.py
@@ -21,7 +21,17 @@ class CustomTokenObtainPairView(TokenObtainPairView):
             refresh_token = tokens['refresh']
 
             res = Response()
-            res.data = {'success': True}
+            username = request.data['username']
+            user = User.objects.get(username=username)
+            group_ids = [group.id for group in user.groups.all()]
+            user_json = {
+                "username": user.username,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+                "email": user.email,
+                "groups": group_ids
+            }
+            res.data = {'success': True, 'user': user_json}
 
             res.set_cookie(
                 key="access_token",


### PR DESCRIPTION
Fixed an issue where groups weren't adding to the user when registering. Set up the login serializer to also return user info upon successful login.